### PR TITLE
Autofocus on project

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -23,4 +23,12 @@ class Project < ApplicationRecord
 
   validates :user_id, presence: true
   validates :name, length: { maximum: 255 }, allow_nil: true
+
+  after_create :initialize_task
+
+  private
+
+  def initialize_task
+    tasks.create!(user: user)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,6 +33,7 @@ class User < ApplicationRecord
 
   after_initialize :ensure_session_token
   before_validation :truncate_username
+  after_create :initialize_project
 
   has_many :tasks, dependent: :restrict_with_exception
   has_many :projects, dependent: :restrict_with_exception
@@ -60,6 +61,10 @@ class User < ApplicationRecord
   end
 
   private
+
+  def initialize_project
+    projects.create!
+  end
 
   def truncate_username
     return unless username

--- a/frontend/actions/tasks_actions.js
+++ b/frontend/actions/tasks_actions.js
@@ -33,21 +33,19 @@ export const clearErrors = () => ({
 
 // asynchronous actions
 export const createTask = task => dispatch => {
-  return (TASKS.createTask(task)
+  return TASKS.createTask(task)
     .then(newTask => {
       dispatch(receiveTask(newTask));
       return newTask;
-    }
-  )
-)};
+    });
+};
 
 export const updateTask = task => dispatch => {
   return TASKS.updateTask(task)
     .then(returnTask => {
       dispatch(receiveTask(returnTask));
       return returnTask;
-    }
-  );
+    });
 };
 
 export const fetchTasksByProject = projectID => dispatch => {
@@ -55,11 +53,10 @@ export const fetchTasksByProject = projectID => dispatch => {
     .then(projectwithtasks => {
       dispatch(receiveTasksByProject(projectwithtasks))
       return projectwithtasks.tasks;
-    }
-  )
+    });
 };
 
 export const destroyTask = id => dispatch => {
   return TASKS.deleteTask(id)
-    .then( () => dispatch(deleteTask(id)) );
+    .then(() => dispatch(deleteTask(id)));
 };

--- a/frontend/components/projects/projects.jsx
+++ b/frontend/components/projects/projects.jsx
@@ -27,24 +27,24 @@ class Projects extends React.Component {
     )
   }
 
-  componentWillReceiveProps (nextProps) {
-    if (Object.keys(nextProps.projects).length === 0) {
-      const newProject2 = {
-        name: "",
-        team_id: 1,
-        user_id: this.currentUser.id
-      };
-      this.props.createProject(newProject2).then (
-        () => {
-          const newItem = document.getElementById("project0");
-          if (newItem) {
-            newItem.focus();
-            newItem.click();
-          }
-        }
-      )
-    };
-  }
+  // componentWillReceiveProps (nextProps) {
+  //   if (Object.keys(this.props.projects).length === 0 && Object.keys(nextProps.projects).length === 0) {
+  //     const newProject2 = {
+  //       name: "",
+  //       team_id: 1,
+  //       user_id: this.currentUser.id
+  //     };
+  //     this.props.createProject(newProject2).then (
+  //       () => {
+  //         const newItem = document.getElementById("project0");
+  //         if (newItem) {
+  //           newItem.focus();
+  //           newItem.click();
+  //         }
+  //       }
+  //     )
+  //   };
+  // }
 
   respondToEnterWithCreate (event, i) {
     event.preventDefault();

--- a/frontend/components/projects/projects.jsx
+++ b/frontend/components/projects/projects.jsx
@@ -98,7 +98,10 @@ class Projects extends React.Component {
 
       if (key === 'ArrowUp' || keyCode === 38) {
         event.preventDefault();
-        const previousItem = document.getElementById(`project${String(parseInt(i) - 1)}`);
+        previousProjectNumber = String(parseInt(i) - 1;
+        if (previousProjectNumber < 0) return null;
+
+        const previousItem = document.getElementById(`project${previousProjectNumber}`);
         if (previousItem) {
           previousItem.focus();
           previousItem.click();

--- a/frontend/components/projects/projects.jsx
+++ b/frontend/components/projects/projects.jsx
@@ -16,7 +16,15 @@ class Projects extends React.Component {
   }
 
   componentWillMount () {
-    this.props.fetchProjects();
+    this.props.fetchProjects().then (
+      () => {
+        const newItem = document.getElementById("project0");
+        if (newItem) {
+          newItem.focus();
+          newItem.click();
+        }
+      }
+    )
   }
 
   componentWillReceiveProps (nextProps) {

--- a/frontend/components/projects/projects.jsx
+++ b/frontend/components/projects/projects.jsx
@@ -98,10 +98,10 @@ class Projects extends React.Component {
 
       if (key === 'ArrowUp' || keyCode === 38) {
         event.preventDefault();
-        previousProjectNumber = String(parseInt(i) - 1;
+        const previousProjectNumber = (parseInt(i) - 1);
         if (previousProjectNumber < 0) return null;
 
-        const previousItem = document.getElementById(`project${previousProjectNumber}`);
+        const previousItem = document.getElementById(`project${String(previousProjectNumber)}`);
         if (previousItem) {
           previousItem.focus();
           previousItem.click();
@@ -113,7 +113,6 @@ class Projects extends React.Component {
           nextItem.focus();
           nextItem.click();
         }
-      } else {
       }
     }
   }

--- a/frontend/components/projects/projects.jsx
+++ b/frontend/components/projects/projects.jsx
@@ -31,18 +31,30 @@ class Projects extends React.Component {
   respondToEnterWithCreate (event, i) {
     event.preventDefault();
 
-    const newProject = {
-      name: "",
-      team_id: 1,
-      user_id: this.currentUser.id
-    }
-    // set a new project in the database
-    this.props.createProject(newProject);
-
     const nextItem = document.getElementById(`project${String(parseInt(i) + 1)}`);
     if (nextItem) {
       nextItem.focus();
       nextItem.click();
+    }
+
+    const newProject = {
+      name: "",
+      team_id: 1,
+      user_id: this.currentUser.id
+    };
+    
+    // set a new project in the database
+    // when the newest item is the last item, move after creating it
+    if (nextItem) {
+      this.props.createProject(newProject);
+    } else {
+      this.props.createProject(newProject).then( () => {
+        const newItem = document.getElementById(`project${String(parseInt(i) + 1)}`);
+        if (newItem) {
+          newItem.focus();
+          newItem.click();
+        }
+      })
     }
   };
 

--- a/frontend/components/projects/projects.jsx
+++ b/frontend/components/projects/projects.jsx
@@ -13,6 +13,7 @@ class Projects extends React.Component {
     this.handleInput = this.handleInput.bind(this);
     this.respondToEnterWithCreate = this.respondToEnterWithCreate.bind(this);
     this.respondToDeleteWhenEmpty = this.respondToDeleteWhenEmpty.bind(this);
+    this.decideIfDeletable = this.decideIfDeletable.bind(this);
   }
 
   componentWillMount () {
@@ -26,25 +27,6 @@ class Projects extends React.Component {
       }
     )
   }
-
-  // componentWillReceiveProps (nextProps) {
-  //   if (Object.keys(this.props.projects).length === 0 && Object.keys(nextProps.projects).length === 0) {
-  //     const newProject2 = {
-  //       name: "",
-  //       team_id: 1,
-  //       user_id: this.currentUser.id
-  //     };
-  //     this.props.createProject(newProject2).then (
-  //       () => {
-  //         const newItem = document.getElementById("project0");
-  //         if (newItem) {
-  //           newItem.focus();
-  //           newItem.click();
-  //         }
-  //       }
-  //     )
-  //   };
-  // }
 
   respondToEnterWithCreate (event, i) {
     event.preventDefault();
@@ -82,6 +64,18 @@ class Projects extends React.Component {
     }
   };
 
+  decideIfDeletable (event, key, keyCode) {
+    // our input must be empty
+    if (event.target.value.length !== 0) return false
+    // it must be a delete key
+    if (key === 'Delete' || key === 'Backspace' || keyCode === 8 || keyCode === 46) {
+      if (Object.keys(this.props.projects).length > 1) {
+        return true
+      }
+    }
+    return false
+  }
+
   handleKeyDown (projectID, i) {
     return (event) => {
       const key = event.key;
@@ -90,15 +84,7 @@ class Projects extends React.Component {
       if (key === 'Enter' || keyCode === 13) {
         this.respondToEnterWithCreate(event, i);
       } else {
-        const empty = (event.target.value.length === 0);
-        const deleteKeys = (
-          key === 'Delete' ||
-          key === 'Backspace' ||
-          keyCode === 8 ||
-          keyCode === 46
-        );
-        const mustBeOneProject = (Object.keys(this.props.projects).length > 1);
-        if (empty && mustBeOneProject && deleteKeys) {
+        if (this.decideIfDeletable(event, key, keyCode)) {
           this.respondToDeleteWhenEmpty(event, projectID, i);
         }
       }

--- a/frontend/components/projects/projects_container.js
+++ b/frontend/components/projects/projects_container.js
@@ -7,7 +7,6 @@ import {
 } from '../../actions/projects_actions';
 import Projects from './projects';
 import { withRouter } from 'react-router';
-import { createTask } from '../../actions/tasks_actions';
 
 const mapStateToProps = state => ({
   currentUser: state.session.currentUser,
@@ -16,7 +15,6 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch => ({
-  createTask: (task) => dispatch(createTask(task)),
   createProject: (project) => dispatch(createProject(project)),
   destroyProject: (id) => dispatch(destroyProject(id)),
   fetchProjects: () => dispatch(fetchProjects()),

--- a/frontend/components/tasks/tasks.jsx
+++ b/frontend/components/tasks/tasks.jsx
@@ -40,6 +40,12 @@ class Tasks extends React.Component {
       if (key === 'Enter' || keyCode === 13) {
         const projectID = parseInt(this.props.match.params.id);
 
+        // Move down 1 in the list by focusing on the next item
+        const nextItem = document.getElementById(`task${String(parseInt(i) + 1)}`);
+        if (nextItem) {
+          nextItem.focus();
+        }
+
         const newTask = {
           title: "",
           team_id: 1,
@@ -50,13 +56,16 @@ class Tasks extends React.Component {
         };
 
         // push the new task to the database
-        this.props.createTask(newTask)
-
-        // Move down 1 in the list by focusing on the next item
-        const nextItem = document.getElementById(`task${String(parseInt(i) + 1)}`);
+        // when the newest item is the last item, move after creating it
         if (nextItem) {
-          nextItem.focus();
+          this.props.createTask(newTask);
+        } else {
+          this.props.createTask(newTask).then( () => {
+            const newItem = document.getElementById(`task${String(parseInt(i) + 1)}`)
+            newItem.focus();
+          });
         }
+
       } else {
         const empty = (event.target.value.length === 0);
         const mustBeOneTask = (Object.keys(this.props.tasks).length > 1);

--- a/frontend/components/tasks/tasks.jsx
+++ b/frontend/components/tasks/tasks.jsx
@@ -11,7 +11,7 @@ class Tasks extends React.Component {
     this.handleKeyDown = this.handleKeyDown.bind(this);
     this.handleKeyUp = this.handleKeyUp.bind(this);
     this.handleInput = this.handleInput.bind(this);
-    this.handleInitialization = this.handleInitialization.bind(this);
+    // this.handleInitialization = this.handleInitialization.bind(this);
   }
 
   componentWillMount () {
@@ -19,11 +19,11 @@ class Tasks extends React.Component {
     if (this.props.match.params.id) {
       projectID = parseInt(this.props.match.params.id);
       this.props.fetchTasksByProject(projectID)
-        .then( (fetchedTasks) => {
-          if (fetchedTasks.length === 0) {
-            this.handleInitialization(projectID);
-          }
-        });
+        // .then( (fetchedTasks) => {
+        //   if (fetchedTasks.length === 0) {
+        //     this.handleInitialization(projectID);
+        //   }
+        // });
     }
   }
 
@@ -34,26 +34,27 @@ class Tasks extends React.Component {
     }
 
     if (projectID && this.props.match.params.id !== nextProps.match.params.id ) {
-      this.props.fetchTasksByProject(projectID).then((tasks) => {
-        if (tasks.length === 0) {
-          this.handleInitialization(projectID);
-        }
-      });
+      this.props.fetchTasksByProject(projectID)
+      // .then((tasks) => {
+      //   if (tasks.length === 0) {
+      //     this.handleInitialization(projectID);
+      //   }
+      // });
     }
   }
 
-  handleInitialization (projectID) {
-    const mustHaveTask = {
-      title: "",
-      team_id: 1,
-      project_id: projectID,
-      user_id: this.currentUser.id,
-      done: false,
-      section: false
-    };
-
-    this.props.createTask(mustHaveTask);
-  }
+  // handleInitialization (projectID) {
+  //   const mustHaveTask = {
+  //     title: "",
+  //     team_id: 1,
+  //     project_id: projectID,
+  //     user_id: this.currentUser.id,
+  //     done: false,
+  //     section: false
+  //   };
+  //
+  //   this.props.createTask(mustHaveTask);
+  // }
 
   handleKeyDown (taskID, i) {
     return (event) => {

--- a/frontend/components/tasks/tasks.jsx
+++ b/frontend/components/tasks/tasks.jsx
@@ -11,7 +11,6 @@ class Tasks extends React.Component {
     this.handleKeyDown = this.handleKeyDown.bind(this);
     this.handleKeyUp = this.handleKeyUp.bind(this);
     this.handleInput = this.handleInput.bind(this);
-    // this.handleInitialization = this.handleInitialization.bind(this);
   }
 
   componentWillMount () {
@@ -19,11 +18,6 @@ class Tasks extends React.Component {
     if (this.props.match.params.id) {
       projectID = parseInt(this.props.match.params.id);
       this.props.fetchTasksByProject(projectID)
-        // .then( (fetchedTasks) => {
-        //   if (fetchedTasks.length === 0) {
-        //     this.handleInitialization(projectID);
-        //   }
-        // });
     }
   }
 
@@ -35,26 +29,8 @@ class Tasks extends React.Component {
 
     if (projectID && this.props.match.params.id !== nextProps.match.params.id ) {
       this.props.fetchTasksByProject(projectID)
-      // .then((tasks) => {
-      //   if (tasks.length === 0) {
-      //     this.handleInitialization(projectID);
-      //   }
-      // });
     }
   }
-
-  // handleInitialization (projectID) {
-  //   const mustHaveTask = {
-  //     title: "",
-  //     team_id: 1,
-  //     project_id: projectID,
-  //     user_id: this.currentUser.id,
-  //     done: false,
-  //     section: false
-  //   };
-  //
-  //   this.props.createTask(mustHaveTask);
-  // }
 
   handleKeyDown (taskID, i) {
     return (event) => {

--- a/spec/system/react_projects_spec.rb
+++ b/spec/system/react_projects_spec.rb
@@ -91,6 +91,17 @@ RSpec.describe "React Project Changes", type: :system do
         expect(page.evaluate_script("document.activeElement.id")).to eq "project0"
       end
 
+      it "stops going up at the top of the list" do
+        expect do
+          expect(page).to have_field("project1")
+
+          seeded_project = find_by_id("project0")
+          seeded_project.native.send_keys(:up)
+          seeded_project.native.send_keys(:up)
+          expect(page.evaluate_script("document.activeElement.id")).to eq "project0"
+        end.not_to raise_error
+      end
+
       it "changes focus after hitting enter" do
         expect(page).to have_field("project0")
         expect(page).to have_field("project1")

--- a/spec/system/react_projects_spec.rb
+++ b/spec/system/react_projects_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "React Project Changes", type: :system do
     end
 
     let(:team) { create(:team) }
-    let!(:project) { create(:project, user: user, team: team) }
+    let!(:project) { user.projects.last }
 
     # it makes a project when there is no project
 
@@ -63,7 +63,7 @@ RSpec.describe "React Project Changes", type: :system do
       expect(page).to have_field("project1")
     end
 
-    context "with 2 seeded projects" do
+    context "with an additional seeded project" do
       let!(:second_project) { create(:project, user: user, team: team) }
 
       it "can delete a 2nd project" do
@@ -104,7 +104,6 @@ RSpec.describe "React Project Changes", type: :system do
       end
 
       context "with empty project names" do
-        let!(:project) { create(:project, user: user, team: team, name: "") }
         let!(:second_project) { create(:project, user: user, team: team, name: "") }
 
         it "focuses on the last remaining project after deleting the end of the list" do

--- a/spec/system/react_tasks_spec.rb
+++ b/spec/system/react_tasks_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "React Tasks Changes", type: :system do
       click_button "Sign In"
     end
 
-    it "begins with a task already int" do
+    it "begins with a task already" do
       expect do
         expect(page).not_to have_field("task0")
         find_by_id("project0").click # TODO: this is kind of an anti-feature on first login
@@ -82,6 +82,30 @@ RSpec.describe "React Tasks Changes", type: :system do
             expect(page).not_to have_field("task1")
           end
         end.to change(Task, :count).by(-1)
+      end
+
+      it "focuses on the last remaining task after deleting the end of the list" do
+        expect(page).to have_field("task0")
+        expect(page).to have_field("task1")
+        expect(page).not_to have_field("task2")
+
+        latest_task = find_by_id("task1")
+        (latest_task.value.length + 1).times { latest_task.send_keys [:delete] }
+
+        expect(page).not_to have_field("task1")
+        expect(page.evaluate_script("document.activeElement.id")).to eq "task0"
+      end
+
+      it "focuses on the last remaining task after deleting the beginning of the list" do
+        expect(page).to have_field("task0")
+        expect(page).to have_field("task1")
+        expect(page).not_to have_field("task2")
+
+        first_task = find_by_id("task0")
+        (first_task.value.length + 1).times { first_task.send_keys [:backspace] }
+
+        expect(page).not_to have_field("task1")
+        expect(page.evaluate_script("document.activeElement.id")).to eq "task0"
       end
     end
   end

--- a/spec/system/react_tasks_spec.rb
+++ b/spec/system/react_tasks_spec.rb
@@ -161,8 +161,7 @@ RSpec.describe "React Tasks Changes", type: :system do
 
         expect do
           ActiveRecord::Base.after_transaction do
-            fill_in "task1", with: "F"
-            debugger
+            fill_in "task1", with: ""
             newly_entered_task = find_by_id("task1")
             (newly_entered_task.value.length + 1).times { newly_entered_task.send_keys [:backspace] }
             expect(page).not_to have_field("task1")

--- a/spec/system/react_tasks_spec.rb
+++ b/spec/system/react_tasks_spec.rb
@@ -161,7 +161,8 @@ RSpec.describe "React Tasks Changes", type: :system do
 
         expect do
           ActiveRecord::Base.after_transaction do
-            fill_in "task1", with: "test"
+            fill_in "task1", with: "F"
+            debugger
             newly_entered_task = find_by_id("task1")
             (newly_entered_task.value.length + 1).times { newly_entered_task.send_keys [:backspace] }
             expect(page).not_to have_field("task1")

--- a/spec/system/react_tasks_spec.rb
+++ b/spec/system/react_tasks_spec.rb
@@ -33,14 +33,14 @@ RSpec.describe "React Tasks Changes", type: :system do
       end.not_to change(Task, :count)
     end
 
-    it 'steps through a stream of newly entered tasks' do
+    it "steps through a stream of newly entered tasks" do
       expect do
         2.times do |n|
           ActiveRecord::Base.after_transaction do
             last_task = find_by_id("task#{n}")
             last_task.native.send_keys(:enter)
-            expect(page).to have_field("task#{n+1}", with: "")
-            expect(page.evaluate_script("document.activeElement.id")).to eq "task#{n+1}"
+            expect(page).to have_field("task#{n + 1}", with: "")
+            expect(page.evaluate_script("document.activeElement.id")).to eq "task#{n + 1}"
           end
         end
       end.to change(Task, :count).by(2)

--- a/spec/system/react_tasks_spec.rb
+++ b/spec/system/react_tasks_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe "React Tasks Changes", type: :system do
       end.to change(Task, :count).by(1)
     end
 
-    context "with justthe initial task" do
+    context "with just the initial task" do
       it "cannot delete the only task" do
         expect(page).to have_field("task0")
         expect(page).not_to have_field("task1")

--- a/spec/system/react_tasks_spec.rb
+++ b/spec/system/react_tasks_spec.rb
@@ -49,9 +49,12 @@ RSpec.describe "React Tasks Changes", type: :system do
       let!(:task) { create(:task, user: user, team: team, project: project) }
       let!(:second_task) { create(:task, user: user, team: team, project: project) }
 
-      it "can fill in tasks" do
+      it 'clicking project focuses it' do
         find_by_id("project0").click
         expect(page.evaluate_script("document.activeElement.id")).to eq "project0"
+      end
+
+      it "can fill in tasks" do
         fill_in "task0", with: "This is my first task"
         fill_in "task1", with: "This is my second task"
         expect(page).to have_field("task0", with: "This is my first task")
@@ -93,7 +96,7 @@ RSpec.describe "React Tasks Changes", type: :system do
     end
   end
 
-  context "when signed in and visiting the project path" do
+  context "when signed in" do
     before do
       visit "/"
 
@@ -106,7 +109,6 @@ RSpec.describe "React Tasks Changes", type: :system do
       Timeout.timeout(Capybara.default_max_wait_time) do
         sleep(0.1) until page.has_content?("Welcome #{user.username}")
       end
-      visit "/#/projects/#{project.id}"
     end
 
     it "can enter a new task" do
@@ -141,7 +143,6 @@ RSpec.describe "React Tasks Changes", type: :system do
       end
 
       it "can update a task" do
-        find_by_id("project0").click
         expect(page).to have_field("task0")
         expect(page).to have_field("task0", with: task.title)
 

--- a/spec/system/react_tasks_spec.rb
+++ b/spec/system/react_tasks_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "React Tasks Changes", type: :system do
       let!(:task) { create(:task, user: user, team: team, project: project) }
       let!(:second_task) { create(:task, user: user, team: team, project: project) }
 
-      it 'clicking project focuses it' do
+      it "clicking project focuses it" do
         find_by_id("project0").click
         expect(page.evaluate_script("document.activeElement.id")).to eq "project0"
       end
@@ -62,8 +62,6 @@ RSpec.describe "React Tasks Changes", type: :system do
       end
 
       it "can navigate between tasks" do
-        find_by_id("project0").click
-        expect(page.evaluate_script("document.activeElement.id")).to eq "project0"
         expect(page).to have_field("task0")
         expect(page).to have_field("task1")
 
@@ -79,10 +77,6 @@ RSpec.describe "React Tasks Changes", type: :system do
       end
 
       it "can delete the 2nd seeded task" do
-        find_by_id("project0").click
-        Timeout.timeout(Capybara.default_max_wait_time) do
-          sleep(0.1) until page.has_field?("task1")
-        end
         fill_in "task1", with: "R"
         short_task = find_by_id("task1")
 
@@ -96,7 +90,7 @@ RSpec.describe "React Tasks Changes", type: :system do
     end
   end
 
-  context "when signed in" do
+  context "when signed in with a load await" do
     before do
       visit "/"
 
@@ -143,14 +137,14 @@ RSpec.describe "React Tasks Changes", type: :system do
       end
 
       it "can update a task" do
-        expect(page).to have_field("task0")
-        expect(page).to have_field("task0", with: task.title)
+        find_by_id("project0").click
+        seeded_task = find_by_id("task0")
+        seeded_task.native.send_keys("F")
+        expect(page.evaluate_script("document.activeElement.id")).to eq "task0"
 
         expect do
-          seeded_task = find_by_id("task0")
-          seeded_task.native.send_keys("F")
-          page.execute_script %{ $("#task0").trigger('keyup') }
           ActiveRecord::Base.after_transaction do
+            page.execute_script %{ $("#task0").trigger('keyup') }
             expect(page).to have_field("task0", with: "#{task.title}F")
           end
         end.to change { Task.last.reload.title }.from(task.title).to("#{task.title}F")

--- a/spec/system/react_tasks_spec.rb
+++ b/spec/system/react_tasks_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe "React Tasks Changes", type: :system do
         expect(page).not_to have_field("task2")
 
         latest_task = find_by_id("task1")
-        (latest_task.value.length + 1).times { latest_task.send_keys [:delete] }
+        (latest_task.value.length + 1).times { latest_task.send_keys [:backspace] }
 
         expect(page).not_to have_field("task1")
         expect(page.evaluate_script("document.activeElement.id")).to eq "task0"


### PR DESCRIPTION
In this PR:
* Solve timing issues by moving task and project initialization from the front end to the back end (both for new users and when creating each new project)
* Move before new object creation unless the newest object is the last in the list -- then move after object creation
* Factor out more front end helper functions
* Increase test cases and refactor tests to accommodate backend initialization